### PR TITLE
Fix Phaser CDN path

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>Seed Synthesis</title>
   <style>html,body{margin:0;background:#222}</style>
-  <script src="https://cdn.jsdelivr.net/npm/[email protected]/dist/phaser.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.min.js"></script>
   <script type="module" src="game.js"></script>
 </head>
 <body></body>


### PR DESCRIPTION
## Summary
- fix CDN path for Phaser in index.html

## Testing
- `curl -I https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.min.js`
- `python3 -m http.server 8123` (fails if port busy)

------
https://chatgpt.com/codex/tasks/task_e_684023e009cc832c8000eb2968173ec7