### PR TITLE
Fix version text placement

### DIFF
--- a/game.js
+++ b/game.js
@@ -128,14 +128,19 @@ class Title extends Phaser.Scene {
     });
 
     // Version display
-    this.add.text(
+    this.versionText = this.add.text(
       CANVAS_WIDTH - 4,
       CANVAS_HEIGHT - 4,
       VERSION,
       { font: '12px Arial', fill: '#ffffff' }
     )
       .setOrigin(1,1)
-      .setDepth(2000);
+      .setDepth(10000);
+
+    this.scale.on('resize', (gameSize) => {
+      const { width, height } = gameSize;
+      this.versionText.setPosition(width - 4, height - 4);
+    });
   }
 }
 
@@ -338,14 +343,19 @@ class Farm extends Phaser.Scene {
     });
 
     // Version display
-    this.add.text(
+    this.versionText = this.add.text(
       CANVAS_WIDTH - 4,
       CANVAS_HEIGHT - 4,
       VERSION,
       { font: '12px Arial', fill: '#ffffff' }
     )
       .setOrigin(1,1)
-      .setDepth(2000);
+      .setDepth(10000);
+
+    this.scale.on('resize', (gameSize) => {
+      const { width, height } = gameSize;
+      this.versionText.setPosition(width - 4, height - 4);
+    });
 
     // Load saved game state before timers
     this.loadGame();


### PR DESCRIPTION
## Summary
- reposition version text using scale resize events
- raise version text depth so it's never hidden

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -c game.js`

------
https://chatgpt.com/codex/tasks/task_e_68406d676870832cb8b563e27ebb959c