### PR TITLE
Fix slider scale when canvas isn't created yet

### DIFF
--- a/game.js
+++ b/game.js
@@ -48,7 +48,10 @@ const PARCEL_SIZE     = 5;
 const UNLOCK_PRICES   = [
   1000, 5000, 10000, 25000, 100000, 200000, 300000, 1000000
 ];
-const VERSION = "v.0.1.5";
+const VERSION = "v.0.1.7";
+
+// Margin around the edges of the canvas where no game objects are placed
+const BUFFER_MARGIN = 32;
 
 // Intro timing constants (in milliseconds)
 const INTRO_FADE_DURATION = 500;
@@ -129,8 +132,8 @@ class Title extends Phaser.Scene {
 
     // Version display
     this.versionText = this.add.text(
-      CANVAS_WIDTH - 4,
-      CANVAS_HEIGHT - 4,
+      CANVAS_WIDTH - BUFFER_MARGIN,
+      CANVAS_HEIGHT - BUFFER_MARGIN,
       VERSION,
       { font: '12px Arial', fill: '#ffffff' }
     )
@@ -139,7 +142,7 @@ class Title extends Phaser.Scene {
 
     this.scale.on('resize', (gameSize) => {
       const { width, height } = gameSize;
-      this.versionText.setPosition(width - 4, height - 4);
+      this.versionText.setPosition(width - BUFFER_MARGIN, height - BUFFER_MARGIN);
     });
   }
 }
@@ -179,8 +182,17 @@ class Farm extends Phaser.Scene {
     this.farmGirlTimer = null;
 
     // compute offsets to roughly center the grid and sidebars
-    this.offsetX = Math.max(0, Math.floor((CANVAS_WIDTH - (SIDEBAR_WIDTH + GRID_COLS * TILE_SIZE + RIGHT_SIDEBAR_WIDTH)) / 2));
-    this.offsetY = Math.max(0, Math.floor((CANVAS_HEIGHT - GRID_ROWS * TILE_SIZE) / 2));
+    this.offsetX = Math.max(
+      BUFFER_MARGIN,
+      Math.floor(
+        (CANVAS_WIDTH -
+          (SIDEBAR_WIDTH + GRID_COLS * TILE_SIZE + RIGHT_SIDEBAR_WIDTH)) / 2
+      )
+    );
+    this.offsetY = Math.max(
+      BUFFER_MARGIN,
+      Math.floor((CANVAS_HEIGHT - GRID_ROWS * TILE_SIZE) / 2)
+    );
 
     // b. Draw the 15×15 Grid Background and lock overlays
     for (let row = 0; row < GRID_ROWS; row++) {
@@ -344,8 +356,8 @@ class Farm extends Phaser.Scene {
 
     // Version display
     this.versionText = this.add.text(
-      CANVAS_WIDTH - 4,
-      CANVAS_HEIGHT - 4,
+      CANVAS_WIDTH - BUFFER_MARGIN,
+      CANVAS_HEIGHT - BUFFER_MARGIN,
       VERSION,
       { font: '12px Arial', fill: '#ffffff' }
     )
@@ -354,7 +366,7 @@ class Farm extends Phaser.Scene {
 
     this.scale.on('resize', (gameSize) => {
       const { width, height } = gameSize;
-      this.versionText.setPosition(width - 4, height - 4);
+      this.versionText.setPosition(width - BUFFER_MARGIN, height - BUFFER_MARGIN);
     });
 
     // Load saved game state before timers

--- a/index.html
+++ b/index.html
@@ -19,15 +19,27 @@
   <input id="scaleSlider" type="range" min="0.5" max="2" value="1" step="0.1">
   <script>
     const slider = document.getElementById('scaleSlider');
-    const canvas = document.querySelector('canvas');
+
     function updateScale() {
+      const canvas = document.querySelector('canvas');
+      if (!canvas) return;
       const scale = parseFloat(slider.value);
       canvas.style.transformOrigin = 'top left';
       canvas.style.transform = `scale(${scale})`;
     }
+
+    function applyScaleWhenCanvasReady() {
+      const canvas = document.querySelector('canvas');
+      if (canvas) {
+        updateScale();
+      } else {
+        requestAnimationFrame(applyScaleWhenCanvasReady);
+      }
+    }
+
     slider.addEventListener('input', updateScale);
-    // Apply initial scale once the canvas is available
-    window.addEventListener('load', updateScale);
+    // Apply initial scale after the game creates the canvas
+    window.addEventListener('load', applyScaleWhenCanvasReady);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix scaling slider crash if the Phaser canvas isn't available at page load
- add 32px buffer margin around the edges of the game
- bump version to v.0.1.7

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68407aae78d0832cb1a7cc05a26a1dff